### PR TITLE
Implement support for --audio-index

### DIFF
--- a/alass-cli/src/lib.rs
+++ b/alass-cli/src/lib.rs
@@ -251,6 +251,7 @@ impl VideoFileHandler {
 
     pub fn open_video_file(
         file_path: &Path,
+        audio_index: Option<usize>,
         video_decode_progress: impl video_decoder::ProgressHandler,
     ) -> Result<VideoFileHandler, InputVideoError> {
         //video_decoder::VideoDecoder::decode(file_path, );
@@ -291,7 +292,7 @@ impl VideoFileHandler {
 
         let chunk_processor = video_decoder::ChunkedAudioReceiver::new(80, vad_processor);
 
-        let vad_buffer = video_decoder::VideoDecoder::decode(file_path, chunk_processor, video_decode_progress)
+        let vad_buffer = video_decoder::VideoDecoder::decode(file_path, audio_index, chunk_processor, video_decode_progress)
             .with_context(|_| InputVideoErrorKind::FailedToDecode {
                 path: PathBuf::from(file_path),
             })?;
@@ -355,6 +356,7 @@ impl VideoFileHandler {
 impl InputFileHandler {
     pub fn open(
         file_path: &Path,
+        audio_index: Option<usize>,
         sub_encoding: &'static Encoding,
         sub_fps: f64,
         video_decode_progress: impl video_decoder::ProgressHandler,
@@ -371,7 +373,7 @@ impl InputFileHandler {
             }
         }
 
-        return Ok(VideoFileHandler::open_video_file(file_path, video_decode_progress)
+        return Ok(VideoFileHandler::open_video_file(file_path, audio_index, video_decode_progress)
             .map(|v| InputFileHandler::Video(v))
             .with_context(|_| InputFileErrorKind::VideoFile(file_path.to_path_buf()))?);
     }


### PR DESCRIPTION
Hey, thanks for creating such a useful tool.

I was running into a problem where my reference video had multiple audio streams in different languages, and the alignment would be slightly different depending on the language I was aligning against. I wanted a little more control, so I went ahead and implemented the functionality myself.

This PR adds an `--audio-index` command line parameter that can be used to specify which audio stream within a video to use as the reference.

I'm somewhat of a novice when it comes to Rust, so apologies in advance if there's anything terribly off.

I couldn't get ffmpeg-sys built in my environment, so I didn't have a chance to try out the `ffmpeg_library` implemenation, but I think that it should work. `ffmpeg_binary` works fine.