### PR TITLE
CLI: Document the "_" debug feature

### DIFF
--- a/alass-cli/src/main.rs
+++ b/alass-cli/src/main.rs
@@ -152,7 +152,7 @@ fn parse_args() -> Result<Arguments, InputArgumentsError> {
             .help("Path to the reference subtitle or video file")
             .required(true))
         .arg(Arg::with_name("incorrect-sub-file")
-            .help("Path to the incorrect subtitle file")
+            .help("Path to the incorrect subtitle file. Entering \"_\" here creates debug subtitles, which can later be used as a reference file.")
             .required(true))
         .arg(Arg::with_name("output-file-path")
             .help("Path to corrected subtitle file")


### PR DESCRIPTION
Adds a line describing how "_" can be used, without trying to go into too much detail. (But, for example, users grepping the help output for "debug" will find it).

Closes: https://github.com/kaegi/alass/issues/38 (or what is left of it, given the feature itself is already there)